### PR TITLE
Add new method get_page_links on WebPageDataScrappers

### DIFF
--- a/methods/extractors/webPageDataScrappers.py
+++ b/methods/extractors/webPageDataScrappers.py
@@ -59,3 +59,11 @@ class WebPageDataScrappers:
             if search_text in line
         ]
         return occurrences
+
+    def get_page_links(self, url):
+        all_links = []
+        all_tags_a = self.get_tag_content('a')
+        for link in all_tags_a:
+            complete_link = url + link['href']
+            all_links.append(complete_link)
+        return all_links


### PR DESCRIPTION
Create a new method that gets all the internal links from the current page. The user can use these links to navigate to another part of the website later. This PR refers to issue #38.