### PR TITLE
Fix issue #45

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11
 
 COPY ./src /app
+COPY pyproject.toml poetry.lock* /app/
 
 WORKDIR /app
 


### PR DESCRIPTION
Adicionando COPY para pyproject.toml e poetry.lock no Dockerfile

Este commit corrige o Dockerfile adicionando uma linha para copiar
os arquivos pyproject.toml e poetry.lock (se existente) para o
diretório /app no container. Isso assegura que as dependências
definidas sejam corretamente reconhecidas e instaladas pelo Poetry
durante o processo de build da imagem Docker.

A inclusão do asterisco em poetry.lock* permite que o processo de build
continue mesmo na ausência do arquivo de lock, tornando o Dockerfile
mais flexível para diferentes cenários de desenvolvimento.
